### PR TITLE
Fixed "brew outdated" command warnings

### DIFF
--- a/Formula/iterm2-cli.rb
+++ b/Formula/iterm2-cli.rb
@@ -4,7 +4,7 @@ class Iterm2Cli < Formula
   homepage "https://github.com/suin/iterm2-cli/"
   url 'https://github.com/suin/iterm2-cli/archive/1.0.0.tar.gz'
   head "https://github.com/suin/iterm2-cli.git"
-  sha1 "574d11a97487de41f8e09f0834abb7cc002fbf0d"
+  sha256 "92a2c679fae4aedb46e130cf223dda9f8adb6c0fc4bfb3ca7bf183bd9b574c15"
 
   def install
     # zsh_completion.install "etc/iterm2_completion.zsh"


### PR DESCRIPTION
Warning: Calling Formula.sha1 is deprecated!
Use Formula.sha256 instead.
/usr/local/Library/Taps/suin/homebrew-suin/Formula/iterm2-cli.rb:7:in `class:Iterm2Cli'
Please report this to the suin/suin tap!

Warning: Calling SoftwareSpec#sha1 is deprecated!
Use SoftwareSpec#sha256 instead.
/usr/local/Library/Taps/suin/homebrew-suin/Formula/iterm2-cli.rb:7:in `class:Iterm2Cli'
Please report this to the suin/suin tap!

Warning: Calling Resource#sha1 is deprecated!
Use Resource#sha256 instead.
/usr/local/Library/Taps/suin/homebrew-suin/Formula/iterm2-cli.rb:7:in `class:Iterm2Cli'
Please report this to the suin/suin tap
